### PR TITLE
Add workflow file to awake Render

### DIFF
--- a/.github/workflows/render-awake.yml
+++ b/.github/workflows/render-awake.yml
@@ -1,0 +1,19 @@
+name: Render Awake
+
+on:
+  schedule:
+    - cron: "*/14 * * * *"
+  workflow_dispatch:
+
+jobs:
+  render-awake:
+    name: Render Awake
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install cURL
+        run: sudo apt install curl
+        shell: bash
+
+      - name: Access to Render
+        run: curl --silent --show-error https://cobuilder-api.onrender.com/
+        shell: bash


### PR DESCRIPTION
- バックエンドに 14 分ごとにアクセスするワークフローを書いておきました。注意点としては、GitHub Action の cron job は必ずしも時間通りには動かないです。本当は、ちゃんとしたサービスを使うべきではあります。